### PR TITLE
Bump maven to 3.5.4 and vespa to 7.310.25

### DIFF
--- a/vespa/.m2/settings.xml
+++ b/vespa/.m2/settings.xml
@@ -1,0 +1,10 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd">
+    <servers>
+        <server>
+            <id>my.datomic.com</id>
+            <username>${env.DATOMIC_REPO_USERNAME}</username>
+            <password>${env.DATOMIC_REPO_PASSWORD}</password>
+        </server>
+    </servers>
+</settings>

--- a/vespa/Dockerfile
+++ b/vespa/Dockerfile
@@ -1,4 +1,4 @@
-FROM vespaengine/vespa:7.200.54
+FROM vespaengine/vespa:7.310.25
 
 RUN yum -y install sudo java-11-openjdk-devel python-pip
 RUN update-alternatives --set java /usr/lib/jvm/java-11-openjdk-11.0.8.10-0.el7_8.x86_64/bin/java

--- a/vespa/Dockerfile
+++ b/vespa/Dockerfile
@@ -1,6 +1,6 @@
 FROM vespaengine/vespa:7.310.25
 
-RUN yum -y install sudo java-11-openjdk-devel python-pip
+RUN yum -y install sudo java-11.0.8-openjdk-devel python-pip
 RUN update-alternatives --set java /usr/lib/jvm/java-11-openjdk-11.0.8.10-0.el7_8.x86_64/bin/java
 RUN update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-11.0.8.10-0.el7_8.x86_64/bin/javac
 

--- a/vespa/Dockerfile
+++ b/vespa/Dockerfile
@@ -1,4 +1,4 @@
-FROM vespaengine/vespa:7.104.46
+FROM vespaengine/vespa:7.200.54
 
 RUN yum -y install sudo java-11-openjdk-devel python-pip
 RUN update-alternatives --set java /usr/lib/jvm/java-11-openjdk-11.0.6.10-1.el7_7.x86_64/bin/java
@@ -11,6 +11,10 @@ RUN mkdir /usr/local/maven
 RUN mv apache-maven-3.3.9/ /usr/local/maven/
 RUN alternatives --install /usr/bin/mvn mvn /usr/local/maven/apache-maven-3.3.9/bin/mvn 1
 RUN alternatives --set mvn /usr/local/maven/apache-maven-3.3.9/bin/mvn
+
+### configure mvn
+RUN mkdir -p /home/circleci/.m2
+COPY --chown=circleci:circleci .m2 /home/circleci/.m2
 
 # install awscli
 RUN pip install --upgrade pip

--- a/vespa/Dockerfile
+++ b/vespa/Dockerfile
@@ -1,20 +1,16 @@
 FROM vespaengine/vespa:7.200.54
 
 RUN yum -y install sudo java-11-openjdk-devel python-pip
-RUN update-alternatives --set java /usr/lib/jvm/java-11-openjdk-11.0.6.10-1.el7_7.x86_64/bin/java
-RUN update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-11.0.6.10-1.el7_7.x86_64/bin/javac
+RUN update-alternatives --set java /usr/lib/jvm/java-11-openjdk-11.0.8.10-0.el7_8.x86_64/bin/java
+RUN update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-11.0.8.10-0.el7_8.x86_64/bin/javac
 
 # mvn
-RUN curl -LO http://www.eu.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz
-RUN tar xzf apache-maven-3.3.9-bin.tar.gz
+RUN curl -LO https://downloads.apache.org/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz
+RUN tar xzf apache-maven-3.5.4-bin.tar.gz
 RUN mkdir /usr/local/maven
-RUN mv apache-maven-3.3.9/ /usr/local/maven/
-RUN alternatives --install /usr/bin/mvn mvn /usr/local/maven/apache-maven-3.3.9/bin/mvn 1
-RUN alternatives --set mvn /usr/local/maven/apache-maven-3.3.9/bin/mvn
-
-### configure mvn
-RUN mkdir -p /home/circleci/.m2
-COPY --chown=circleci:circleci .m2 /home/circleci/.m2
+RUN mv apache-maven-3.5.4/ /usr/local/maven/
+RUN alternatives --install /usr/bin/mvn mvn /usr/local/maven/apache-maven-3.5.4/bin/mvn 1
+RUN alternatives --set mvn /usr/local/maven/apache-maven-3.5.4/bin/mvn
 
 # install awscli
 RUN pip install --upgrade pip
@@ -32,6 +28,10 @@ RUN adduser circleci && \
 
 USER circleci
 RUN ulimit -S -n 262145
+
+### configure mvn
+RUN mkdir -p /home/circleci/.m2
+COPY --chown=circleci:circleci .m2 /home/circleci/.m2
 
 # override vespa entrypoint
 ENTRYPOINT []


### PR DESCRIPTION
Vespa cloud requires newer maven and vespa images. 
This PR updates the docker image that we use on circleci.